### PR TITLE
Fix module generation

### DIFF
--- a/crates/move-ts/src/idl_module.rs
+++ b/crates/move-ts/src/idl_module.rs
@@ -1,6 +1,5 @@
 use crate::{
     format::{gen_doc_string, gen_doc_string_opt},
-    idl_type::generate_idl_type_with_type_args,
     CodeText,
 };
 
@@ -59,15 +58,25 @@ impl<'info> IDLModuleGenerator<'info> {
     }
 
     pub fn generate_entrypoint_bodies(&self, ctx: &CodegenContext) -> Result<CodeText> {
-        ctx.try_join(&self.script_fns)
+        Ok(format!(
+            "{}\n\n{}",
+            ctx.try_join(&self.script_fns)?,
+            ctx.generate(&self.script_fns)?
+        )
+        .into())
     }
 
     pub fn generate_entrypoint_module(&self, ctx: &CodegenContext) -> Result<CodeText> {
+        let sui_imports = "import { RawSigner, ObjectId } from '@mysten/sui.js';\n";
+        let aptos_imports = "import { AptosClient, AptosAccount, Types } from 'aptos';\n";
+
         Ok(format!(
-            "{}{}\nimport * as mod from './index.js';\nimport * as payloads from './payloads.js';\n{}",
+            "{}{}\nimport * as mod from './index.js';\nimport * as payloads from './payloads.js';\n{}{}\n\n{}",
             gen_doc_string("Entrypoint builders.\n\n@module"),
             PRELUDE,
-            self.generate_entrypoint_bodies(ctx)?
+            sui_imports,
+            aptos_imports,
+            self.generate_entrypoint_bodies(ctx)?,
         )
         .into())
     }
@@ -188,37 +197,6 @@ impl Codegen for IDLModule {
             );
         }
 
-        let mut js_func_code = String::from("");
-
-        for script_fn in self.functions.iter() {
-            js_func_code.push_str(&format!("
-  public async {}(", script_fn.name));
-            js_func_code.push_str(&script_fn.ty_args
-                .iter()
-                .map(|a| format!("{}: string", a))
-                .collect::<Vec<_>>()
-                .join(", "));
-            for func_arg in script_fn.args.iter() {
-                let ts_type = &generate_idl_type_with_type_args(&func_arg.ty, ctx, &[], false)?;
-                js_func_code.push_str(&format!("
-    {}: {},", func_arg.name, &ts_type));
-            }
-            let type_args_str = script_fn.ty_args
-                .iter()
-                .map(|a| format!("{}", a))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let args_str = script_fn.args
-                .iter()
-                .map(|a| format!("{}", a.name))
-                .collect::<Vec<_>>()
-                .join(", ");
-            js_func_code.push_str(&format!("
-  ) {
-    this.callback(\"{}\", [{}], [{}]);
-  }", script_fn.name, &type_args_str, &args_str));
-        }
-
         let ts = format!(
             r#"{}{}
 
@@ -268,16 +246,6 @@ const moduleImpl = {{
 }} as const;
 
 {}export const moduleDefinition = moduleImpl as p.MoveModuleDefinition<"{}", "{}"> as typeof moduleImpl;
- 
-export class Module {{
-  private callback: Function;
-
-  constructor(_callback: Function) {{
-    this.callback = _callback;
-  }}
-
-{}
-}}
 "#,
             gen.generate_module_doc(),
             PRELUDE,
@@ -311,7 +279,6 @@ export class Module {{
             gen_doc_string_opt(&self.doc),
             self.module_id.address().to_hex_literal(),
             name,
-            js_func_code
         );
 
         Ok(ts)

--- a/crates/move-ts/src/idl_module.rs
+++ b/crates/move-ts/src/idl_module.rs
@@ -67,15 +67,19 @@ impl<'info> IDLModuleGenerator<'info> {
     }
 
     pub fn generate_entrypoint_module(&self, ctx: &CodegenContext) -> Result<CodeText> {
-        let sui_imports = "import { RawSigner, ObjectId } from '@mysten/sui.js';\n";
-        let aptos_imports = "import { AptosClient, AptosAccount, Types } from 'aptos';\n";
+        let extra_imports = if cfg!(feature = "address20") {
+            "import { RawSigner, ObjectId } from '@mysten/sui.js';\n"
+        } else if cfg!(feature = "address32") {
+            "import { AptosClient, AptosAccount, Types } from 'aptos';\n"
+        } else {
+            ""
+        };
 
         Ok(format!(
-            "{}{}\nimport * as mod from './index.js';\nimport * as payloads from './payloads.js';\n{}{}\n\n{}",
+            "{}{}\nimport * as mod from './index.js';\nimport * as payloads from './payloads.js';\n{}\n\n{}",
             gen_doc_string("Entrypoint builders.\n\n@module"),
             PRELUDE,
-            sui_imports,
-            aptos_imports,
+            extra_imports,
             self.generate_entrypoint_bodies(ctx)?,
         )
         .into())

--- a/crates/move-ts/src/script_function.rs
+++ b/crates/move-ts/src/script_function.rs
@@ -265,7 +265,6 @@ type TransactionPayload = {{
 
 export class {}AptosModule {{
 	constructor(private readonly client: AptosClient, private readonly account: AptosAccount) {{}}
-
 	{}
 
 	private async sendTransaction(payload: TransactionPayload) {{
@@ -295,8 +294,7 @@ export class {}AptosModule {{
       }},
     }};
   }}
-}}
-						",
+}}",
                 module_name,
                 self.iter()
                     .map(|script_fn| {
@@ -306,8 +304,7 @@ export class {}AptosModule {{
                             "
 	async {}(args: mod.{}) {{
 		return this.sendTransaction({}(args));
-	}}
-",
+	}}",
                             fn_name.to_lower_camel_case(),
                             script_fn.payload_args_type_name(),
                             fn_name,
@@ -330,8 +327,7 @@ private readonly defaultGasBudget = 1000;
 constructor(private readonly signer: RawSigner) {{}}
 
 {}
-}}
-",
+}}",
                 module_name,
                 self.iter()
                     .map(|script_fn| {
@@ -351,8 +347,7 @@ async {}(args: mod.{}, overrides: SuiCallOverrides) {{
 			gasBudget: overrides?.gasBudget ?? this.defaultGasBudget,
 			...overrides,
 	}})
-}}
-",
+}}",
                             fn_name.to_lower_camel_case(),
                             script_fn.payload_args_type_name(),
                             fn_name,
@@ -363,11 +358,13 @@ async {}(args: mod.{}, overrides: SuiCallOverrides) {{
                     .join("")
             );
 
-            if cfg!(feature = "address32") {
-                return Ok(format!("{}", aptos_module));
+            if cfg!(feature = "address20") {
+                return Ok(format!("{}\n", sui_module));
+            } else if cfg!(feature = "address32") {
+                return Ok(format!("{}\n", aptos_module));
+            } else {
+                return Ok(format!(""));
             }
-
-            Ok(format!("{}", sui_module))
         }
     }
 }

--- a/crates/move-ts/src/script_function.rs
+++ b/crates/move-ts/src/script_function.rs
@@ -317,7 +317,6 @@ export class {}AptosModule {{
                     .join("")
             );
 
-						// @todo only generate the module class for Sui if we are in address20 mode
             let sui_module = format!(
                 "
 type SuiCallOverrides = {{
@@ -364,7 +363,11 @@ async {}(args: mod.{}, overrides: SuiCallOverrides) {{
                     .join("")
             );
 
-            Ok(format!("{}\n{}", aptos_module, sui_module))
+            if cfg!(feature = "address32") {
+                return Ok(format!("{}", aptos_module));
+            }
+
+            Ok(format!("{}", sui_module))
         }
     }
 }


### PR DESCRIPTION
# Description

- The current [movehat](https://github.com/pentagonxyz/movehat) repository has the following problems:
  - It assumes the build folder is 1 level up from the current directory which may not always be the case (see `let module = await import("../build/ts/" + moduleName + "/index.ts");`)
  - The arguments in the function definition have the `any` type so the developers don't get any typings benefits.
- This PR attempts to fix the above issue, where it generates a TypeScript class with all the appropriate entry functions for every move module. (Note: the module class will only be generated if a feature flag of either `address32` or `address20` is provided)
- The introduction of this change means that the code `movehat` is redundant for now until we release new features on it, because the developers can just generate the TypeScript using the `move-ts` CLI. Also, since we haven't published the move-tsgen crate, we may want to update the documentation in `movehat` for how to run `move-tsgen` locally.

# Usage

- For example, let's say we have the `governance` module in Aptos and after we generate the TypeScript code, we have a `GovernanceAptosModule`. Then we can use that class in the following:

```
const client = new AptosClient(...);
const account = new AptosAccount(...);
const governance = new GovernanceAptosModule(client, account);
governance.delegate(...);
```

# Note

- There seems to be a problem with compiling the Sui code. For example, I am getting the error when I am trying to generate the TypeScript code for it. By the way, I think Hippos Lab's TS sdk is better than Ian's one at the current state.

```
{
  "error": "Duplicate entry for abort code 0 found in 0000000000000000000000000000000000000002::object, previous entry: ErrorDescription {\n    code_name: \"EBadIDLength\",\n    code_description: \"Attempting to construct an object ID with the wrong number of bytes--expected 20.\",\n}"
}
```
